### PR TITLE
Require only the types that are used

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,12 +24,17 @@ declare namespace EipHop {
 }
 
 export const setupMainHandler: (
-  electronModule: typeof Electron,
+  electronModule: { ipcMain: typeof Electron.ipcMain },
   actions: EipHop.Actions,
   enableLogs?: boolean
 ) => void;
 
-export const setupFrontendListener: (electronModule: typeof Electron) => void;
+export const setupFrontendListener: (electronModule: { 
+  ipcRenderer: {
+    send: typeof Electron.ipcRenderer.send,
+    on: typeof Electron.ipcRenderer.on 
+  }
+}) => void;
 
 export const emit: <Response = any>(
   action: string,


### PR DESCRIPTION
When using it with a preload function you don't have access to the electron in the `window` variable, however you can make an API which have the `send` and `on` functions, and you can pass that into the lib. I also like to import from libraries what is needed like `ipcMain` instead of the whole electron.

Now you can use it like this in TS:
```ts
// preload.ts
contextBridge.exposeInMainWorld('api', {
  send: (channel: string, requestId: string, action: string, payload: any): void => {
    const validChannel = ['asyncRequest'];
    if (validChannel.includes(channel)) {
      ipcRenderer.send(channel, requestId, action, payload);
    }
  },
  on: (channel: string, callback: Function): void => {
    const validChannel = [
      'asyncResponseNotify',
      'asyncResponse',
      'errorResponse',
    ]
    if (validChannel.includes(channel)) {
      // Strip event but pass an empty object to the callback
      ipcRenderer.on(channel, (_event, ...args) => callback({}, ...args));
    }
  }  
});
```

```ts
// main.ts
import { app, ipcMain } from 'electron';
import { setupMainHandler } from 'eiphop';

setupMainHandler({ ipcMain }, { ...actions }, true);

```

```ts
renderer/index.ts

interface Window {
  api: {
    send: typeof Electron.ipcRenderer.send;
    on: typeof Electron.ipcRenderer.on;
  }
}

setupFrontendListener({ ipcRenderer: window.api });
...
```